### PR TITLE
Add a public initializer to Argument

### DIFF
--- a/Chester/QueryBuilder.swift
+++ b/Chester/QueryBuilder.swift
@@ -16,6 +16,11 @@ public struct Argument {
   let key: String
   let value: Any
   
+  public init(key: String, value: Any) {
+    self.key = key
+    self.value = value
+  }
+  
   func build() -> String {
     if value is String {
       return "\(key): \"\(value)\""


### PR DESCRIPTION
For use with Carthage, a public initializer must be provided. From [The Swift Programming Language: Access Control](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/AccessControl.html#//apple_ref/doc/uid/TP40014097-CH41-ID3)

> The default memberwise initializer for a structure type is considered private if any of the structure’s stored properties are private. Likewise, if any of the structure’s stored properties are file private, the initializer is file private. Otherwise, the initializer has an access level of internal.
> 
> As with the default initializer above, if you want a public structure type to be initializable with a memberwise initializer when used in another module, you must provide a public memberwise initializer yourself as part of the type’s definition.
