### PR TITLE
Escape argument strings and serialize Dictionaries and Arrays to GraphQL format

### DIFF
--- a/Chester.xcodeproj/project.pbxproj
+++ b/Chester.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		371630801E8A975400ABDFEE /* GraphQLSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3716307F1E8A975400ABDFEE /* GraphQLSerializable.swift */; };
+		371630821E8AAD1F00ABDFEE /* testQueryArgsWithSpecialCharacters.json in Resources */ = {isa = PBXBuildFile; fileRef = 371630811E8AAD1F00ABDFEE /* testQueryArgsWithSpecialCharacters.json */; };
+		371630841E8AB18500ABDFEE /* testQueryArgsWithDictionary.json in Resources */ = {isa = PBXBuildFile; fileRef = 371630831E8AB18500ABDFEE /* testQueryArgsWithDictionary.json */; };
 		944A3AB81CBA70AF00172E0B /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944A3AB71CBA70AF00172E0B /* Query.swift */; };
 		94A76AAC1CA958E00098F2A9 /* testQueryArgs.json in Resources */ = {isa = PBXBuildFile; fileRef = 94A76AAB1CA958E00098F2A9 /* testQueryArgs.json */; };
 		94A76AAF1CA98BD80098F2A9 /* testQueryWithMultipleRootFields.json in Resources */ = {isa = PBXBuildFile; fileRef = 94A76AAE1CA98BD80098F2A9 /* testQueryWithMultipleRootFields.json */; };
@@ -34,6 +37,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3716307F1E8A975400ABDFEE /* GraphQLSerializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLSerializable.swift; sourceTree = "<group>"; };
+		371630811E8AAD1F00ABDFEE /* testQueryArgsWithSpecialCharacters.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = testQueryArgsWithSpecialCharacters.json; sourceTree = "<group>"; };
+		371630831E8AB18500ABDFEE /* testQueryArgsWithDictionary.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = testQueryArgsWithDictionary.json; sourceTree = "<group>"; };
 		944A3AB71CBA70AF00172E0B /* Query.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
 		94A76AAB1CA958E00098F2A9 /* testQueryArgs.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = testQueryArgs.json; sourceTree = "<group>"; };
 		94A76AAE1CA98BD80098F2A9 /* testQueryWithMultipleRootFields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = testQueryWithMultipleRootFields.json; sourceTree = "<group>"; };
@@ -99,6 +105,7 @@
 				94AE4D581CA81B250079DD8D /* Info.plist */,
 				94AE4D6D1CA81C8C0079DD8D /* QueryBuilder.swift */,
 				944A3AB71CBA70AF00172E0B /* Query.swift */,
+				3716307F1E8A975400ABDFEE /* GraphQLSerializable.swift */,
 			);
 			path = Chester;
 			sourceTree = "<group>";
@@ -112,6 +119,8 @@
 				94AE4D711CA8260F0079DD8D /* testQueryWithSubQuery.json */,
 				94AE4D731CA82ACC0079DD8D /* testQueryWithNestedSubQueries.json */,
 				94A76AAB1CA958E00098F2A9 /* testQueryArgs.json */,
+				371630811E8AAD1F00ABDFEE /* testQueryArgsWithSpecialCharacters.json */,
+				371630831E8AB18500ABDFEE /* testQueryArgsWithDictionary.json */,
 				94E419E11DB3D075009852A6 /* testQueryOn.json */,
 				94E419E31DB3D62A009852A6 /* testQueryOnWithTypename.json */,
 				94A76AAE1CA98BD80098F2A9 /* testQueryWithMultipleRootFields.json */,
@@ -227,9 +236,11 @@
 				94E419E21DB3D075009852A6 /* testQueryOn.json in Resources */,
 				94A76AB11CA9971A0098F2A9 /* testQueryWithMultipleRootFieldsAndArgs.json in Resources */,
 				94AE4D721CA8260F0079DD8D /* testQueryWithSubQuery.json in Resources */,
+				371630821E8AAD1F00ABDFEE /* testQueryArgsWithSpecialCharacters.json in Resources */,
 				94A76AAF1CA98BD80098F2A9 /* testQueryWithMultipleRootFields.json in Resources */,
 				94AE4D701CA820190079DD8D /* testQueryWithFields.json in Resources */,
 				94E419E41DB3D62A009852A6 /* testQueryOnWithTypename.json in Resources */,
+				371630841E8AB18500ABDFEE /* testQueryArgsWithDictionary.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -242,6 +253,7 @@
 			files = (
 				944A3AB81CBA70AF00172E0B /* Query.swift in Sources */,
 				94AE4D6E1CA81C8C0079DD8D /* QueryBuilder.swift in Sources */,
+				371630801E8A975400ABDFEE /* GraphQLSerializable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Chester/GraphQLSerializable.swift
+++ b/Chester/GraphQLSerializable.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+// Types that implement this protocol can specify a custom format for their 
+//GraphQL arguments, and whether quotes are required
+protocol GraphQLSerializable {
+  var asGraphQLString: String { get }
+}
+
+extension GraphQLSerializable {
+  var asGraphQLString: String {
+    get {
+      return "\(self)"
+    }
+  }
+}
+
+extension String: GraphQLSerializable {
+  var asGraphQLString: String {
+    get {
+      return "\"" + escape(string: self) + "\""
+    }
+  }
+  
+  //Escape strings according to https://facebook.github.io/graphql/#sec-String-Value
+  private func escape(string input: String) -> String{
+    var output = ""
+    
+    for scalar in input.unicodeScalars {
+      switch scalar {
+      case "\"":
+        output.append("\\\"")
+      case "\\":
+        output.append("\\\\")
+      case "\u{8}":
+        output.append("\\b")
+      case "\u{c}":
+        output.append("\\f")
+      case "\n":
+        output.append("\\n")
+      case "\r":
+        output.append("\\r")
+      case "\t":
+        output.append("\\t")
+      case UnicodeScalar(0x0)...UnicodeScalar(0xf), UnicodeScalar(0x10)...UnicodeScalar(0x1f):
+        output.append(String(format: "\\u%04x", scalar.value))
+      default:
+        output.append(Character(scalar))
+      }
+    }
+    
+    return output
+  }
+}
+
+extension Dictionary: GraphQLSerializable {
+  var asGraphQLString: String {
+    get {
+      let output = self.map { (key: Key, value: Value) -> String in
+        let serializedValue: String
+        if let value = value as? GraphQLSerializable {
+          serializedValue = value.asGraphQLString
+        } else {
+          serializedValue = "\(value)"
+        }
+
+        return "\(key): \(serializedValue)"
+        }.joined(separator: ",")
+      
+      return "{\(output)}"
+    }
+  }
+}
+
+extension Array: GraphQLSerializable {
+  var asGraphQLString: String {
+    get {
+      let output = self.map { (element: Element) -> String in
+        if let element = element as? GraphQLSerializable {
+          return element.asGraphQLString
+        } else {
+          return "\(element)"
+        }
+      }.joined(separator: ",")
+      
+      return "[\(output)]"
+    }
+  }
+}

--- a/Chester/GraphQLSerializable.swift
+++ b/Chester/GraphQLSerializable.swift
@@ -8,20 +8,16 @@ protocol GraphQLSerializable {
 
 extension GraphQLSerializable {
   var asGraphQLString: String {
-    get {
-      return "\(self)"
-    }
+    return "\(self)"
   }
 }
 
 extension String: GraphQLSerializable {
   var asGraphQLString: String {
-    get {
-      return "\"" + escape(string: self) + "\""
-    }
+    return "\"" + escape(string: self) + "\""
   }
   
-  //Escape strings according to https://facebook.github.io/graphql/#sec-String-Value
+  /// Escape strings according to https://facebook.github.io/graphql/#sec-String-Value
   private func escape(string input: String) -> String{
     var output = ""
     
@@ -54,35 +50,31 @@ extension String: GraphQLSerializable {
 
 extension Dictionary: GraphQLSerializable {
   var asGraphQLString: String {
-    get {
-      let output = self.map { (key: Key, value: Value) -> String in
-        let serializedValue: String
-        if let value = value as? GraphQLSerializable {
-          serializedValue = value.asGraphQLString
-        } else {
-          serializedValue = "\(value)"
-        }
-
-        return "\(key): \(serializedValue)"
-        }.joined(separator: ",")
+    let output = self.map { (key: Key, value: Value) -> String in
+      let serializedValue: String
+      if let value = value as? GraphQLSerializable {
+        serializedValue = value.asGraphQLString
+      } else {
+        serializedValue = "\(value)"
+      }
       
-      return "{\(output)}"
-    }
+      return "\(key): \(serializedValue)"
+      }.joined(separator: ",")
+    
+    return "{\(output)}"
   }
 }
 
 extension Array: GraphQLSerializable {
   var asGraphQLString: String {
-    get {
-      let output = self.map { (element: Element) -> String in
-        if let element = element as? GraphQLSerializable {
-          return element.asGraphQLString
-        } else {
-          return "\(element)"
-        }
+    let output = self.map { (element: Element) -> String in
+      if let element = element as? GraphQLSerializable {
+        return element.asGraphQLString
+      } else {
+        return "\(element)"
+      }
       }.joined(separator: ",")
-      
-      return "[\(output)]"
-    }
+    
+    return "[\(output)]"
   }
 }

--- a/Chester/QueryBuilder.swift
+++ b/Chester/QueryBuilder.swift
@@ -22,11 +22,14 @@ public struct Argument {
   }
   
   func build() -> String {
-    if value is String {
-      return "\(key): \"\(value)\""
+    if let value = value as? GraphQLSerializable {
+      let escapedValue = value.asGraphQLString
+      return "\(key): \(escapedValue)"
+    } else {
+      return "\(key): \(value)"
     }
-    return "\(key): \(value)"
   }
+  
 
 }
 

--- a/ChesterTests/QueryBuilderTests.swift
+++ b/ChesterTests/QueryBuilderTests.swift
@@ -86,6 +86,30 @@ class QueryBuilderTests: XCTestCase {
     XCTAssertEqual(expectation, query)
   }
   
+  func testQueryArgsWithSpecialCharacters() {
+    let query = try! QueryBuilder()
+      .from("posts")
+      .with(arguments: Argument(key: "id", value: 4), Argument(key: "author", value: "\tIs this an \"emoji\"? 👻 \r\n(y\\n)Special\u{8}\u{c}\u{4}\u{1b}"))
+      .with(fields: "id", "title")
+      .build()
+    
+    let expectation = loadExpectationForTest(#function)
+    
+    XCTAssertEqual(expectation, query)
+  }
+  
+  func testQueryArgsWithDictionary() {
+    let query = try! QueryBuilder()
+      .from("posts")
+      .with(arguments: Argument(key: "id", value: 4), Argument(key: "filter", value: [["author": "Chester", "labels": ["recipes"]],["author": "Iskander"]]))
+      .with(fields: "id", "title")
+      .build()
+    
+    let expectation = loadExpectationForTest(#function)
+    
+    XCTAssertEqual(expectation, query)
+  }
+  
   func testQueryWithMultipleRootFields() {
     let query = try! QueryBuilder()
       .from("posts", fields: ["id", "title"])

--- a/ChesterTests/testQueryArgsWithDictionary.json
+++ b/ChesterTests/testQueryArgsWithDictionary.json
@@ -1,0 +1,6 @@
+{
+  posts(id: 4, filter: [{author: "Chester",labels: ["recipes"]},{author: "Iskander"}]) {
+    id,
+    title
+  }
+}

--- a/ChesterTests/testQueryArgsWithSpecialCharacters.json
+++ b/ChesterTests/testQueryArgsWithSpecialCharacters.json
@@ -1,0 +1,6 @@
+{
+  posts(id: 4, author: "\tIs this an \"emoji\"? 👻 \r\n(y\\n)Special\b\f\u0004\u001b") {
+    id,
+    title
+  }
+}


### PR DESCRIPTION
* Escape argument strings, so that they can contain backslashes, quotes, etc. I wrote the sanitizer according to the GraphQL spec.
* Serialize dictionaries and arrays to GraphQL format. It's now possible to pass them as the value of `Argument(key: , value: )`. They will be converted to GraphQL's array and dictionary syntax, which uses curly braces for dictionaries and doesn't quote keys. I used an extension to Dictionary and Array that implement a protocol (GraphQLSerializable) that has a function that returns a serialized representation.
* I added on test for arguments with special characters, and one test with an argument full of dictionaries and arrays.