### PR TITLE
Update Query.swift

### DIFF
--- a/Chester/Query.swift
+++ b/Chester/Query.swift
@@ -40,7 +40,7 @@ struct Query {
   }
   
   func validate() throws {
-    if fields.isEmpty {
+    if fields.isEmpty && subQueries.isEmpty {
       throw QueryError.missingFields
     }
   }


### PR DESCRIPTION
Currently complex queries that contain a lot of subQueries instead of fields aren't possible. 
As a subquery is specifying a field, the validate needs to make sure that both fields and subQueries are empty before throwing the missingFields error.